### PR TITLE
fix missing warnings for gn

### DIFF
--- a/geocatbridge/publish/geonetwork.py
+++ b/geocatbridge/publish/geonetwork.py
@@ -60,6 +60,8 @@ class GeonetworkServer(ServerBase):
     XSLTFILENAME = os.path.join(os.path.dirname(os.path.dirname(__file__)), "resources", "qgis-to-iso19139.xsl")
 
     def __init__(self, name, url="", authid="", profile=0):
+        self._warnings = []
+        self._errors = []
         self.name = name
         self.url = url
         self.authid = authid


### PR DESCRIPTION
resolves an issue with self._warnings undefined
is this the proper way to solve this?

```
2019-10-17T22:30:28     CRITICAL    Traceback (most recent call last):
              File "/Users/geocat/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/geocatbridge/publish/publishtask.py", line 116, in run
              w, e = self.metadataServer.loggedInfo()
              File "/Users/geocat/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/geocatbridge/publish/serverbase.py", line 34, in loggedInfo
              return self._warnings, self._errors
             AttributeError: 'GeonetworkServer' object has no attribute '_warnings'
```