### PR TITLE
Don't crash if userLocale is unset, fixes #164

### DIFF
--- a/geocatbridge/plugin.py
+++ b/geocatbridge/plugin.py
@@ -37,7 +37,7 @@ class GeocatBridge:
 
         self.name = meta.getAppName()
         self.provider = None
-        self.locale = QSettings().value("locale/userLocale")[0:2]
+        self.locale = QSettings().value("locale/userLocale", QLocale().name())[0:2]
         locale_path = files.getLocalePath(f"bridge_{self.locale}")
 
         self.translator = QTranslator()


### PR DESCRIPTION
Fixes a crash if the `locale/userLocale` is unset: https://github.com/GeoCat/qgis-bridge-plugin/issues/164

This does happen in some circumstances for people who use a non-default locale. It is a well-known Plugin Builder bug and has seeped into many places. :)

Theoretically we should use QgsSettings rather than QSettings but I wanted to keep this as minimal as possible.

Any chance that this could lead to a small hotfix release?