### PR TITLE
Recreate isolated flag when "clearing" GeoServer workspace

### DIFF
--- a/geocatbridge/servers/models/geoserver.py
+++ b/geocatbridge/servers/models/geoserver.py
@@ -1066,7 +1066,7 @@ class GeoserverServer(DataCatalogServerBase):
             # Get isolation flag
             url = f"{self.apiUrl}/workspaces/{self.workspace}.json"
             workspace = self.request(url).json()
-            isolated = workspace["workspace"]["isolated"]
+            isolated = workspace.get("workspace", {}).get("isolated", False)
 
         # Delete workspace recursively
         url = f"{self.apiUrl}/workspaces/{self.workspace}.json?recurse=true"


### PR DESCRIPTION
A quick implementation of #168. I bet I missed _something_ :)

By default workspaces are not set to be isolated. In my tests `/workspaces/{self.workspace}.json` _always_ included a "`isolated`" key, either `True` or `False`.

E.g.:
```
{
    'workspace': {
        'name': 'test',
        'isolated': False,
        'dateCreated': '2024-04-03 09:45:46.752 UTC',
        'dataStores': ..., 
        'coverageStores': ..., 
        'wmsStores': ..., 
        'wmtsStores': ...
    }
}
```

This change retrieves the existing workspace's "isolated" value and applies them when creating the new workspace.

This would fix #168 