### PR TITLE
Build About HTML dynamically, fixes crash in read-only installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,3 @@ venv.bak/
 .run/
 .idea/
 *debug/
-
-# Do not check in rendered HTML
-/geocatbridge/resources/geocat/index.html

--- a/geocatbridge/resources/geocat/template.html
+++ b/geocatbridge/resources/geocat/template.html
@@ -107,7 +107,7 @@
             <div class="gc-logo-ext-container">
                <a href="{{ repo_url }}" title="Source code on GitHub">
                   <div class="gc-logo-ext-wrapper">
-                     <img class="gc-logo-ext" src="img/github_logo.svg" alt="GitHub">
+                     <img class="gc-logo-ext" src="file:///{{ about_dir }}/img/github_logo.svg" alt="GitHub">
                   </div>
                   <div class="gc-logo-ext-label">GitHub</div>
                </a>
@@ -115,7 +115,7 @@
             <div class="gc-logo-ext-container">
                <a href="https://gitter.im/GeoCat/Bridge" title="Chat on Gitter">
                   <div class="gc-logo-ext-wrapper">
-                     <img class="gc-logo-ext" src="img/gitter_logo.svg" alt="Gitter">
+                     <img class="gc-logo-ext" src="file:///{{ about_dir }}/img/gitter_logo.svg" alt="Gitter">
                   </div>
                   <div class="gc-logo-ext-label">Gitter</div>
                </a>
@@ -126,7 +126,7 @@
       <td class="gc-right-column">
          <div class="gc-logo-wrapper">
             <a href="https://www.geocat.net">
-               <img class="gc-logo" src="img/geocat_logo.svg" alt="GeoCat">
+               <img class="gc-logo" src="file:///{{ about_dir }}/img/geocat_logo.svg" alt="GeoCat">
             </a>
          </div>
          {% if is_enterprise %}

--- a/geocatbridge/ui/bridgedialog.py
+++ b/geocatbridge/ui/bridgedialog.py
@@ -68,8 +68,6 @@ class BridgeDialog(BASE, WIDGET):
         cur_version = meta.getVersion()
         old_version = meta.SemanticVersion(QSettings().value(VERSION_SETTING) or '')
         if old_version != cur_version:
-            # Force-refresh the About HTML page
-            files.getAboutUrl(True)
             QSettings().setValue(VERSION_SETTING, str(cur_version))
             return True
         return False

--- a/geocatbridge/ui/geocatwidget.py
+++ b/geocatbridge/ui/geocatwidget.py
@@ -5,7 +5,7 @@ from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtWebKitWidgets import QWebPage
 
 from geocatbridge.utils import gui, meta
-from geocatbridge.utils.files import getAboutUrl
+from geocatbridge.utils.files import getAboutHtml
 
 WIDGET, BASE = gui.loadUiType(__file__)
 
@@ -17,7 +17,7 @@ class GeoCatWidget(WIDGET, BASE):
         self.parent = parent
         self.setupUi(self)
 
-        self.txtAbout.load(getAboutUrl())
+        self.txtAbout.setHtml(getAboutHtml())
         self.txtAbout.page().setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
         self.txtAbout.linkClicked.connect(partial(self.open_link))
 


### PR DESCRIPTION
Currently the plugin renders the About HTML page to a file with its current version information etc. The file is saved in the plugin's directory. This directory might not be writable, e.g. if the plugin is installed as a core plugin in a shared user environment with a shared QGIS installation.

This changes the About HTML page to be rendered every time it is needed. Embedded local images are linked via `file:///` URLs.

Rendering the page to a string takes about 3 milliseconds on my system.

# Checks
I looked through the code to see where files are written and could not find any other such instances. Usually temporary files in the system's temp directory are used. The only place I am not sure about is `bridgestyle/bridgestyle/style2style.py` but from what I can see that script is not used by the plugin. So I think this change covers all attempts of the plugin to write into its own directory. 🤞

# (Manual) Tests
I have tested this on:
- Linux (Manjaro) with QGIS 3.22.16 (newer QGIS on my system does not have QtWebkit anymore)
- Windows 10 with QGIS 3.34.4

The about page shows up fine and the images are displayed.

I do not have a Mac OS environment to test but I assume that the `file:///` path should work there as well as it worked fine on Linux.

-----

Fixes https://github.com/GeoCat/qgis-bridge-plugin/issues/171