### PR TITLE
Recreate workspace specific settings and namespace when "clearing" GeoServer workspace

### DIFF
--- a/geocatbridge/servers/models/geoserver.py
+++ b/geocatbridge/servers/models/geoserver.py
@@ -1055,6 +1055,7 @@ class GeoserverServer(DataCatalogServerBase):
         service_settings = {}
         workspace_settings = None
         if recreate:
+            # Collect all data stores
             url = f"{self.apiUrl}/workspaces/{self.workspace}/datastores.json"
             stores = self.request(url).json().get("dataStores", {}) or {}
             for store in stores.get("dataStore", []):
@@ -1081,6 +1082,7 @@ class GeoserverServer(DataCatalogServerBase):
             url = f"{self.apiUrl}/workspaces/{self.workspace}.json"
             workspace = self.request(url).json()
             isolated = workspace.get("workspace", {}).get("isolated", False)
+
             # Get security rules / ACL
             url = f"{self.apiUrl}/security/acl/layers.json"
             existing_acl_rules = self.request(url).json()
@@ -1101,6 +1103,7 @@ class GeoserverServer(DataCatalogServerBase):
                         pass
                     else:
                         raise
+
             # Get settings override
             url = f"{self.apiUrl}/workspaces/{self.workspace}/settings.json"
             workspace_settings = self.request(url).json()

--- a/geocatbridge/servers/models/geoserver.py
+++ b/geocatbridge/servers/models/geoserver.py
@@ -1266,7 +1266,7 @@ class GeoserverServer(DataCatalogServerBase):
 
     def _createWorkspace(
             self,
-            namespace: dict[str, dict],
+            namespace: Optional[dict[str, dict]] = None,
             isolated: bool = False,
             acl_rules: Optional[dict[str, str]] = None,
             service_settings: Optional[dict[str, dict]] = None,
@@ -1277,8 +1277,8 @@ class GeoserverServer(DataCatalogServerBase):
         ws = {"workspace": {"name": self.workspace, "isolated": isolated}}
         self.request(url, data=ws, method="post")
 
-        self._setWorkspaceNamespace(namespace)
-
+        if namespace:
+            self._setWorkspaceNamespace(namespace)
         if acl_rules:
             self._setWorkspaceACL(acl_rules)
         if service_settings:


### PR DESCRIPTION
Fixes https://github.com/GeoCat/qgis-bridge-plugin/issues/177

Upon workspace "clearing" (actually a deletion and creation of a new workspace) this:

1. Checks the workspace for workspace specific settings (behind the Settings checkbox on a workspace page in the web UI)
2. Checks if it considers them to be the default values erroneously returned and if so, discards them (https://github.com/GeoCat/qgis-bridge-plugin/issues/177, https://osgeo-org.atlassian.net/browse/GEOS-11361)
3. Applies them to the newly created workspace

This seems to be a bit buggy on GeoServer's end.

I would consider it an improvement to the plugin anyways because
Before: Settings were always lost.
Now: Only settings that happen to match those default-ish values will get lost. Otherwise the user's settings will be transferred to the new workspace.

-----
This is the last one! If I had known that I would do all those settings I would have made one single PR, sorry for the spam. :)