### PR TITLE
Fix crash when layer path is too long [GEOCAT-004035]

### DIFF
--- a/geocatbridge/utils/layers.py
+++ b/geocatbridge/utils/layers.py
@@ -215,8 +215,12 @@ def isSupportedLayer(layer):
         return False
     if layer.isTemporary():
         uri = layer.source()
-        if not (uri and Path(uri).exists()):
-            # Temporary layers are only supported if the source is an actual path (on disk)
+        try:
+            if not (uri and Path(uri).exists()):
+                # Temporary layers are only supported if the source is an actual path (on disk)
+                return False
+        except OSError:
+            # If the path is invalid (e.g. too long), the layer is not supported either way [#004035]
             return False
     return (layer.isValid() and layer.isSpatial() and layer.crs().isValid() and
             layer.type() in (QgsMapLayer.VectorLayer, QgsMapLayer.RasterLayer) and


### PR DESCRIPTION
Bridge crashes [here](https://github.com/GeoCat/qgis-bridge-plugin/commit/cfb737ec1f431b6dd453ddc8fea7cba8bef64390#diff-8c64828f53342ed4be38fd01e3abe6b2a2d41bf785362325d4006a10e0bbfe98R218) when a layer is _temporary_ and its URI exceeds the maximum path length for the specific OS:

```
OSError: [Errno 36] File name too long
```

This fix wraps the line (that was introduced to fix #163) in a try/except to prevent this crash from happening. Will also prevent other `OSError`s that may arise when parsing the URI as a `Path`.

Thanks @geraldo for reporting.